### PR TITLE
Fixes 3 bugs: define() calls without dependencies, "require" as a dependency, and `define.amd = {}`

### DIFF
--- a/hazelnut.js
+++ b/hazelnut.js
@@ -2,6 +2,12 @@
 	var modules = {},
 		factories = {};
 
+	function makeRequireFn(relId, module) {
+		return function requireFn(id) {
+			return id==='exports' ? module.exports : (id==='module' ? module : (id==='require' ? requireFn : require(rel(id, relId))));
+		};
+	}
+
 	function require(id) {
 		if (id.pop) id=id[0];
 		var m = modules[id];
@@ -10,9 +16,8 @@
 		if (!m) {
 			m = { id: id, exports: {} };
 			modules[id] = m;
-			m.exports = factories[id].apply(m, factories[id].deps.map(function(n) {
-				return n==='exports' ? m.exports : (n==='module' ? m : require(rel(n, id)));
-			})) || m.exports;
+			var requireFn = makeRequireFn(id, m);
+			m.exports = factories[id].apply(m, factories[id].deps.map(requireFn)) || m.exports;
 		}
 
 		return m.exports;

--- a/hazelnut.js
+++ b/hazelnut.js
@@ -30,7 +30,7 @@
 	function define(id, deps, factory) {
 		if (id in factories) throw new Error(id + ' already defined');
 		if (!factory)
-			factory = deps;
+			(factory = deps).deps = [];
 		else
 			factory.deps = deps;
 		factories[id] = factory;

--- a/hazelnut.js
+++ b/hazelnut.js
@@ -35,7 +35,7 @@
 			factory.deps = deps;
 		factories[id] = factory;
 	}
-	define.amd = true;
+	define.amd = {};
 	g.define = define;
 
 	function rel(name, path) {


### PR DESCRIPTION
The commit log explains the bugs in full.  I realize that this increases hazelnuts size, but some gentle refactoring can shrink it back down.  Plus, hazelnut was not working for me until I fixed these bugs.

As an aside, I just noticed that you pushed this project to github only hours before I needed to use it.  Talk about good timing!
