### PR TITLE
Enables private, hidden hazelnut, not exposed on the global object

### DIFF
--- a/hazelnut.js
+++ b/hazelnut.js
@@ -1,8 +1,9 @@
-(function(g) {
+var require, define;
+(function() {
 	var modules = {},
 		factories = {};
 
-	function require(id) {
+	(require = function(id) {
 		if (id.pop) id=id[0];
 		var m = modules[id];
 
@@ -15,17 +16,15 @@
 		}
 
 		return m.exports;
-	}
-	(g.require = require).config = valueOf;
+	}).config = valueOf;
 
-	function define(id, deps, factory) {
+	(define = function(id, deps, factory) {
 		(factories[id] = (typeof(factory = factory || deps)!=='function') ? function(){return factory;} : factory).deps = deps.pop ? deps : [];
-	}
-	(g.define = define).amd = {};
+	}).amd = {};
 
 	function rel(name, path) {
 		name = name.replace(/^(?:\.\/|(\.\.\/))/, path.replace(/[^\/]+$/g,'') + '$1');
 		while ( name !== (name=name.replace(/[^\/]+\/\.\.\/?/g, '') ) );
 		return name;
 	}
-})(this);
+})();


### PR DESCRIPTION
In some cases, I want to use an AMD shim internally within a library that I've written in AMD.  However, I don't want to set define or require on the global object; they should remain hidden inside the module's private scope.

I copied the technique used from almond, so I assume it'll work in all environments.
